### PR TITLE
Update GTM event for no search results

### DIFF
--- a/public/js/src/custom/search.js
+++ b/public/js/src/custom/search.js
@@ -126,9 +126,9 @@
                     empty: () => {                        
                         window.dataLayer.push({
                             'event': 'event',
-                            'eventCategory': 'search--used',
+                            'eventCategory': 'search--searched-result',
                             'eventAction': searchTerm,
-                            'eventLabel': '',
+                            'eventLabel': '0',
                         });
 
                         // Template for a empty result


### PR DESCRIPTION
### Motivation

The event for no search results was named incorrectly, causing mismatches in reports.